### PR TITLE
Fix typos and improve clarity in multiple documentation files

### DIFF
--- a/docs/2-existing-mechanisms.md
+++ b/docs/2-existing-mechanisms.md
@@ -1,7 +1,7 @@
 # 2. Tradeoffs of Existing Mechanisms
 
 The existing suite of protocol funding mechanisms have so far adequately supported the ecosystem, but come with their own tradeoffs: 
-- Typically not forward looking, eg. they are usually retroactive
+- Typically not forward-looking, eg. they are usually retroactive
 - Tend to favor projects/teams instead of individuals
 - Formed around mediating institutions
 - Do not typically give exposure to the upside of application layer

--- a/docs/7-anticipated-concerns.md
+++ b/docs/7-anticipated-concerns.md
@@ -5,7 +5,7 @@ While we can't conceive of every scenario, we've tried to think critically about
 ## 7.1 Related to Operations
 
 **What happens in the case of stolen/exploited funds being sent to the mechanism?**
-- To the best of our knowledge this has not happened to any other public goods project or individual, but that doesn't mean it wont happen, however unlikely. While the membership will ultimately decide how to handle each scenario individually, each should be carefully considered. It might play out something like this: Contract receives illicit funds > Membership collectively decides to claim/burn the specific funds in the contract > The affected parties deploy a recovery contract with a snapshot at each exploit and restore the funds via said contract.
+- To the best of our knowledge this has not happened to any other public goods project or individual, but that doesn't mean it won't happen, however unlikely. While the membership will ultimately decide how to handle each scenario individually, each should be carefully considered. It might play out something like this: Contract receives illicit funds > Membership collectively decides to claim/burn the specific funds in the contract > The affected parties deploy a recovery contract with a snapshot at each exploit and restore the funds via said contract.
 
 **Shouldn't one-off contributions be considered for membership?**
 - Every mechanism has its limit. The Protocol Guild may meet its at the edges of contribution, where someone has meaningfully contributed to a project, but does not work on it consistently, or produces something as a one-off. This remains an open question, and might be considered for a future weighting scheme if there are no major issues.

--- a/docs/8-case-studies.md
+++ b/docs/8-case-studies.md
@@ -34,7 +34,7 @@ Projects which previously launched a token could donate a portion of the tokens 
 |:-------:| ------------:| -----------:| -------------:|
 | **SUM** |  $48,471,770 | $96,943,539 |  $145,415,309 |
 
-Already we can see the significant benefit these donations would have. For these scenarios, we include 150 members on the split contract plus a 4 year vesting period.
+Already we can see the significant benefit these donations would have. For these scenarios, we include 150 members on the split contract plus a 4-year vesting period.
 
 ![](https://i.imgur.com/i3xI4bu.png)
 


### PR DESCRIPTION
This pull request addresses several typographical and grammatical errors across various documentation files:

- **7-anticipated-concerns.md**: Corrected "wont" to "won't".
- **8-case-studies.md**: Added hyphen in "4-year" and corrected formatting.
- **2-existing-mechanisms.md**: Added hyphen in "forward-looking".

These changes aim to improve readability, consistency, and overall clarity across the documentation.
